### PR TITLE
remove frontmatter from other file types when reading in a query

### DIFF
--- a/R/table_functions.R
+++ b/R/table_functions.R
@@ -48,8 +48,8 @@ query_from_str <- function(query) {
       stop(paste0("No parameter 'sql' found in file ", query))
     }
   } else if (file.exists(query)) {
-    # Query is in a file; read it
-    query <- paste(readLines(query), collapse = "\n")
+    # Query is in a file; read it; remove frontmatter
+    query <- gsub("^---\n.*---\n", "", paste(readLines(query), collapse = "\n"))
   }
   query
 }


### PR DESCRIPTION
Mostly helpful/intended for `.sql` files. Will remove frontmatter that is not intended to be in the query sent to a database.

Will turn a file like this:

```sql
---
operator: airflow.providers.sqlite.operators.sqlite.SqliteOperator
---

SELECT *
FROM my_awesome_table
```

into a query like this:

```sql
SELECT *
FROM my_awesome_table
```
